### PR TITLE
makes two section variables in MonoidalSectionsWhiskered.v implicit

### DIFF
--- a/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
+++ b/UniMath/Bicategories/MonoidalCategories/ActionBasedStrongFunctorsWhiskeredMonoidal.v
@@ -1903,8 +1903,7 @@ Section Main.
 
       (** using sections already for this direction *)
       Lemma param_distr_bicat_to_monoidal_section_data:
-        smonoidal_data V montrafotargetbicat_disp Mon_V
-                       montrafotargetbicat_disp_monoidal
+        smonoidal_data Mon_V montrafotargetbicat_disp_monoidal
                        (nat_trafo_to_section_bicat a0 a0' H H' δ).
       Proof.
         split.
@@ -1925,14 +1924,14 @@ Section Main.
       Qed.
       (** the two equations were thus exactly the ingredients for the data of a monoidal section *)
 
-      Lemma param_distr_bicat_to_monoidal_section_laws: smonoidal_laxlaws V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal param_distr_bicat_to_monoidal_section_data.
+      Lemma param_distr_bicat_to_monoidal_section_laws: smonoidal_laxlaws Mon_V montrafotargetbicat_disp_monoidal param_distr_bicat_to_monoidal_section_data.
       Proof.
         repeat split; red; intros; apply trafotargetbicat_disp_cells_isaprop.
       Qed.
 
       Lemma param_distr_bicat_to_monoidal_section_strongtensor:
-        smonoidal_strongtensor V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal
-                               (smonoidal_preserves_tensor V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal
+        smonoidal_strongtensor Mon_V montrafotargetbicat_disp_monoidal
+                               (smonoidal_preserves_tensor Mon_V montrafotargetbicat_disp_monoidal
                                                            param_distr_bicat_to_monoidal_section_data).
       Proof.
         intros v w.
@@ -1948,8 +1947,8 @@ Section Main.
       Qed.
 
       Lemma param_distr_bicat_to_monoidal_section_strongunit:
-        smonoidal_strongunit V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal
-                             (smonoidal_preserves_unit V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal
+        smonoidal_strongunit Mon_V montrafotargetbicat_disp_monoidal
+                             (smonoidal_preserves_unit Mon_V montrafotargetbicat_disp_monoidal
                                                        param_distr_bicat_to_monoidal_section_data).
       Proof.
         use tpair.
@@ -1979,7 +1978,7 @@ Defined.
     Section FromMonoidalSectionBicat.
 
       Context {sd: section_disp montrafotargetbicat_disp}.
-      Context (ms: smonoidal_data V montrafotargetbicat_disp Mon_V montrafotargetbicat_disp_monoidal sd).
+      Context (ms: smonoidal_data Mon_V montrafotargetbicat_disp_monoidal sd).
       (** since the laws were anyway trivial to establish, we do not need more than [smonoidal_data] *)
 
       Definition δ_from_ms: H ⟹ H' := section_to_nat_trafo_bicat _ _ _ _ sd.
@@ -1987,7 +1986,7 @@ Defined.
       Lemma δtr_eq_from_ms: param_distr_bicat_triangle_eq_variant0 δ_from_ms.
       Proof.
         red.
-        assert (aux := smonoidal_preserves_unit _ _ _ _ ms).
+        assert (aux := smonoidal_preserves_unit _ _ ms).
         cbn in aux.
         rewrite hcomp_identity_left, hcomp_identity_right in aux.
         rewrite (functor_id FA), (functor_id FA') in aux.
@@ -2000,7 +1999,7 @@ Defined.
       Lemma δpe_eq_from_ms: param_distr_bicat_pentagon_eq_variant δ_from_ms.
       Proof.
         intros v w.
-        assert (aux := smonoidal_preserves_tensor _ _ _ _ ms v w).
+        assert (aux := smonoidal_preserves_tensor _ _ ms v w).
         cbn in aux.
         rewrite hcomp_identity_left, hcomp_identity_right in aux.
         rewrite (functor_id FA), (functor_id FA') in aux.
@@ -2112,33 +2111,27 @@ Defined.
       Qed.
 
       Definition param_distr'_to_monoidal_section_data:
-        smonoidal_data V montrafotarget_disp Mon_V montrafotarget_disp_monoidal montrafotarget_section_disp :=
+        smonoidal_data Mon_V montrafotarget_disp_monoidal montrafotarget_section_disp :=
         param_distr_bicat_to_monoidal_section_data(C:=bicat_of_cats) FAm FA'm G
                              (parameterized_distributivity'_nat_as_instance δ) δtr_eq' δpe_eq'.
 
       Definition param_distr'_to_monoidal_section_laws:
-        smonoidal_laxlaws V montrafotarget_disp Mon_V
-                       montrafotarget_disp_monoidal
-                       param_distr'_to_monoidal_section_data :=
+        smonoidal_laxlaws Mon_V montrafotarget_disp_monoidal
+                          param_distr'_to_monoidal_section_data :=
         param_distr_bicat_to_monoidal_section_laws FAm FA'm G δ δtr_eq' δpe_eq'.
 
       Definition param_distr'_to_monoidal_section_strongtensor:
-        smonoidal_strongtensor V montrafotarget_disp Mon_V montrafotarget_disp_monoidal
-                               (smonoidal_preserves_tensor V
-                                                           montrafotarget_disp
-                                                           Mon_V
+        smonoidal_strongtensor Mon_V montrafotarget_disp_monoidal
+                               (smonoidal_preserves_tensor Mon_V
                                                            montrafotarget_disp_monoidal
                                                            param_distr'_to_monoidal_section_data) :=
         param_distr_bicat_to_monoidal_section_strongtensor FAm FA'm G δ δtr_eq' δpe_eq'.
 
       Definition param_distr'_to_monoidal_section_strongunit:
-        smonoidal_strongunit V montrafotarget_disp Mon_V montrafotarget_disp_monoidal
-                               (smonoidal_preserves_unit V
-                                                           montrafotarget_disp
-                                                           Mon_V
-                                                           montrafotarget_disp_monoidal
-                                                           param_distr'_to_monoidal_section_data)
-        :=
+        smonoidal_strongunit Mon_V montrafotarget_disp_monoidal
+                             (smonoidal_preserves_unit Mon_V
+                                                       montrafotarget_disp_monoidal
+                                                       param_distr'_to_monoidal_section_data) :=
         param_distr_bicat_to_monoidal_section_strongunit FAm FA'm G δ δtr_eq' δpe_eq'.
 
       Definition param_distr'_to_functor: V ⟶ montrafotarget_totalcat :=
@@ -2161,7 +2154,7 @@ End IntoMonoidalSection.
 Section FromMonoidalSection.
 
       Context {sd: section_disp montrafotarget_disp}.
-      Context (ms: smonoidal_data V montrafotarget_disp Mon_V montrafotarget_disp_monoidal sd).
+      Context (ms: smonoidal_data Mon_V montrafotarget_disp_monoidal sd).
       (** since the laws were anyway trivial to establish, we do not need more than [smonoidal_data] *)
 
       Definition δ'_from_ms: H ⟹ H' := section_to_nat_trafo_bicat _ _ _ _ sd.

--- a/UniMath/CategoryTheory/Monoidal/MonoidalSectionsWhiskered.v
+++ b/UniMath/CategoryTheory/Monoidal/MonoidalSectionsWhiskered.v
@@ -25,11 +25,9 @@ Section MonoidalSections.
   Import DisplayedBifunctorNotations.
   Import DisplayedMonoidalNotations.
 
-  Variable C : category.
-  Variable D : disp_cat C.
+  Context {C : category} {D : disp_cat C}.
   Local Notation TD := (total_category D).
-  Variable M : monoidal C.
-  Variable DM : disp_monoidal D M.
+  Context (M : monoidal C) (DM : disp_monoidal D M).
   Local Notation TM := (total_monoidal DM).
 
   Definition section_preserves_tensor_data (sd : section_disp D) : UU

--- a/UniMath/CategoryTheory/Monoidal/TotalDisplayedMonoidalWhiskered.v
+++ b/UniMath/CategoryTheory/Monoidal/TotalDisplayedMonoidalWhiskered.v
@@ -313,14 +313,11 @@ Section MonoidalTotalCategory.
     apply idpath.
   Qed.
 
-  (* currently incompatible
-  Definition projection_fmonoidal_laws {C : category} {D : disp_cat C} {M : monoidal C} (DM : disp_monoidal D M) : fmonoidal_laws (projection_fmonoidaldata DM)
+  Definition projection_fmonoidal_laxlaws {C : category} {D : disp_cat C} {M : monoidal C} (DM : disp_monoidal D M) : fmonoidal_laxlaws (projection_fmonoidaldata DM)
     := (projection_preserves_tensornatleft DM,, projection_preserves_tensornatright DM,, projection_preserves_associativity DM,, projection_preserves_leftunitality DM,, projection_preserves_rightunitality DM).
 
-
-  Definition projection_fmonoidal {C : category} {D : disp_cat C} {M : monoidal C} (DM : disp_monoidal D M) : fmonoidal  TM(DM) M π^{D}
-    := (projection_fmonoidaldata DM,, projection_fmonoidal_laws DM).
-*)
+  Definition projection_fmonoidal_lax {C : category} {D : disp_cat C} {M : monoidal C} (DM : disp_monoidal D M) : fmonoidal_lax TM(DM) M π^{D}
+    := (projection_fmonoidaldata DM,, projection_fmonoidal_laxlaws DM).
 
   Definition projection_preservestensor_strictly {C : category} {D : disp_cat C} {M : monoidal C} (DM : disp_monoidal D M) : preserves_tensor_strictly (projection_preserves_tensordata DM).
   Proof.


### PR DESCRIPTION
Variable -> Context
makes use of the file in ActionBasedStrongFunctorsWhiskeredMonoidal.v more readable

I had had the intention to ask for a make function instead, but I see that the lack of implicit arguments was the culprit.