### PR TITLE
more stylistic improvements

### DIFF
--- a/UniMath/Bicategories/MonoidalCategories/UnivalenceOfBicategoryOfUnivMonCats/Tensorlayer.v
+++ b/UniMath/Bicategories/MonoidalCategories/UnivalenceOfBicategoryOfUnivMonCats/Tensorlayer.v
@@ -4,7 +4,7 @@ In this file we construct one side of the first displayed layer above the bicate
 The total category corresponding to this displayed layer is the univalent bicategory defined as follows:
 - The objects are categories together with a binary operation (which will be the tensor product for the monoidal structure).
 - The morphisms are functors which preserve the tensor in a lax/weak sense (i.e. a non-necessarily isomorphic morphism).
-- The 2-cells are natural transformations which (at the unit) commute the tensor-preserving morphisms.
+- The 2-cells are natural transformations which (at tensor products) commute the tensor-preserving morphisms.
 *)
 
 Require Import UniMath.Foundations.All.
@@ -190,14 +190,13 @@ Section TensorLayer.
 
   Definition catcatstensor_disp_ob_mor : disp_cat_ob_mor bicat_of_univ_cats.
   Proof.
-    use tpair.
-    - exact (λ C, tensor C).
-    - exact (λ C D TC TD F, preserves_tensor TC TD F).
+    exists (λ C, tensor C).
+    exact (λ C D TC TD F, preserves_tensor TC TD F).
   Defined.
 
   Definition catcatstensor_disp_id_comp : disp_cat_id_comp bicat_of_univ_cats catcatstensor_disp_ob_mor.
   Proof.
-    use tpair.
+    split.
     - intros C TC.
       apply identityfunctor_preserves_tensor.
     - intros C D E F G TC TD TE.
@@ -264,19 +263,19 @@ Section TensorLayer.
       rewrite tensor_id.
       rewrite id_left.
       apply idpath.
-    -  intros C D F TC TD ptF.
-       intros x y.
-       rewrite id_right.
-       simpl.
-       rewrite tensor_id.
-       rewrite id_left.
-       cbn.
-       unfold compositions_preserves_tensor_data.
-       cbn.
-       unfold identityfunctor_preserves_tensor_data.
-       rewrite functor_id.
-       rewrite id_right.
-       apply idpath.
+    - intros C D F TC TD ptF.
+      intros x y.
+      rewrite id_right.
+      simpl.
+      rewrite tensor_id.
+      rewrite id_left.
+      cbn.
+      unfold compositions_preserves_tensor_data.
+      cbn.
+      unfold identityfunctor_preserves_tensor_data.
+      rewrite functor_id.
+      rewrite id_right.
+      apply idpath.
     - intros C D F TC TD ptF.
       intros x y.
       rewrite id_right.
@@ -338,12 +337,11 @@ Section TensorLayer.
       unfold compositions_preserves_tensor_data.
       rewrite assoc'.
       etrans. {
-        apply cancel_precomposition.
+        apply maponpaths.
         apply (pathsinv0 (functor_comp _ _ _)).
       }
       etrans. {
-        apply cancel_precomposition.
-        apply maponpaths.
+        do 2 apply maponpaths.
         apply ptcα.
       }
       rewrite assoc.
@@ -363,7 +361,7 @@ Section TensorLayer.
 
       etrans. { apply ptnatH. }
       cbn in *.
-      apply cancel_precomposition.
+      apply maponpaths.
       apply idpath.
   Defined.
 
@@ -430,7 +428,6 @@ Section TensorLayer.
       rewrite id_right in ix.
       rewrite tensor_id in ix.
       rewrite id_left in ix.
-      repeat (use tpair).
       repeat (apply impred_isaprop ; intro).
       apply univalent_category_has_homsets.
   Defined.
@@ -468,7 +465,7 @@ Section TensorLayer.
   Definition tensor_iso {C : univalent_category} (TC TD : tensor C) : UU
     := ∑ α : ∏ x y : C, z_iso (x ⊗_{TD} y) (x ⊗_{TC} y),
           ∏ (a1 a2 b1 b2 : C) (f : C⟦a1,a2⟧) (g : C⟦b1,b2⟧),
-          (pr1 (α a1 b1))·(f ⊗^{TC} g) = (f ⊗^{TD} g)·(pr1 (α a2 b2)).
+          (pr1 (α a1 b1)) · (f ⊗^{TC} g) = (f ⊗^{TD} g) · (pr1 (α a2 b2)).
 
   Definition tensor_eq {C : univalent_category} (TC TD : tensor C) : UU
     := ∑ (α : ∏ x y : C, (x ⊗_{TD} y) = (x ⊗_{TC} y)),
@@ -521,7 +518,7 @@ Section TensorLayer.
     rewrite (! idtoiso_postcompose _ _ _ _ _ _) in q.
     rewrite pathsinv0inv0 in q.
     etrans. { apply q. }
-    apply cancel_precomposition.
+    apply maponpaths.
     apply eq_idtoiso_idtomor.
   Qed.
 
@@ -570,7 +567,7 @@ Section TensorLayer.
     : f ⊗^{TC} g
       = transportf (λ x : C, C⟦x , x2 ⊗_{TC} y2⟧) (α x1 y1) (transportf _ (α x2 y2) (f ⊗^{TD} g))
       -> transportf (λ x : C, C⟦x , x2 ⊗_{TC} y2⟧) (! α x1 y1) (f ⊗^{TC} g)
-      = (transportf _ (α x2 y2) (f ⊗^{TD} g)).
+      = transportf _ (α x2 y2) (f ⊗^{TD} g).
   Proof.
     intro q.
     apply (transportf_transpose_left (P :=  (λ x : C, C ⟦ x, x2 ⊗_{ TC} y2 ⟧))).
@@ -645,7 +642,7 @@ Section TensorLayer.
       use make_z_iso.
       + exact (ptd x y).
       + exact (pr1 ptdinv x y).
-      + use tpair.
+      + split.
         * set (t := ptcounit x y).
           cbn in t.
           unfold identityfunctor_preserves_tensor_data in t.
@@ -696,8 +693,7 @@ Section TensorLayer.
       repeat (use tpair).
       * intros x y.
         apply ti.
-      *
-        intros x1 x2 y1 y2 f g.
+      * intros x1 x2 y1 y2 f g.
         induction ti as [n i].
         apply (swap_nat_along_zisos (n x1 y1) (n x2 y2) (f ⊗^{pr1 TD} g) (f ⊗^{pr1 TC} g)).
         exact (i x1 x2 y1 y2 f g).
@@ -720,13 +716,13 @@ Section TensorLayer.
         cbn.
         apply (z_iso_inv_after_z_iso ((pr1 ti x y))).
       + (* axioms *)
-        use tpair.
-        * use tpair.
+        split.
+        * split.
           -- abstract (repeat (apply funextsec ; intro) ;
              apply univalent_category_has_homsets).
           -- apply funextsec ; intro ; apply funextsec ; intro.
              apply univalent_category_has_homsets.
-        * use tpair.
+        * split.
           -- use tpair.
              ++ intros x y.
                 cbn.
@@ -737,7 +733,7 @@ Section TensorLayer.
                 rewrite id_right.
                 rewrite tensor_id.
                 apply (z_iso_after_z_iso_inv ((pr1 ti x y))).
-             ++ use tpair.
+             ++ split.
                 ** abstract (repeat (apply funextsec ; intro) ;
                    apply univalent_category_has_homsets).
                 ** abstract (repeat (apply funextsec ; intro) ;
@@ -752,7 +748,7 @@ Section TensorLayer.
                 rewrite tensor_id.
                 rewrite id_left.
                 apply (! z_iso_inv_after_z_iso ((pr1 ti x y))).
-             ++ use tpair.
+             ++ split.
                 ** abstract (repeat (apply funextsec ; intro) ;
                    apply univalent_category_has_homsets).
                 ** abstract (repeat (apply funextsec ; intro) ;
@@ -988,7 +984,7 @@ Section TensorLayer.
   Qed.
 
   Lemma cancellation_lemma {A B : UU} (a : A) (b : B) (f : A -> B) (g : B -> A)
-    : (∏ b0 : B, f(g(b0)) = b0) -> g(f(a))=g(b) -> f(a)=b.
+    : (∏ b0 : B, f (g b0) = b0) -> g (f a) = g b -> f a = b.
   Proof.
     intros i e.
     set (k0 := ! i (f a)).
@@ -1055,9 +1051,7 @@ Section TensorLayer.
         repeat (apply impred_isaset ; intro).
         apply homset_property.
     - intro T.
-      apply isaset_dirprod.
-      + repeat (repeat (apply impred_isaset ; intro) ; apply isasetaprop ; apply homset_property).
-      + repeat (repeat (apply impred_isaset ; intro) ; apply isasetaprop ; apply homset_property).
+      apply isaset_dirprod; repeat (repeat (apply impred_isaset ; intro) ; apply isasetaprop ; apply homset_property).
   Qed.
 
   Lemma pr_id_tensor_eqi'''_funextsec {C : univalent_category} {TC TD : tensor C} (p : TC = TD) (x y : C)

--- a/UniMath/Bicategories/MonoidalCategories/UnivalenceOfBicategoryOfUnivMonCats/Unitlayer.v
+++ b/UniMath/Bicategories/MonoidalCategories/UnivalenceOfBicategoryOfUnivMonCats/Unitlayer.v
@@ -3,8 +3,8 @@ This is the first of a sequence of files with the purpose of showing that the bi
 In this file we construct one side of the first displayed layer above the bicategory of univalent categories, more precisely:
 The total category corresponding to this displayed layer is the univalent bicategory defined as follows:
 - The objects are categories together with a fixed object (which will be the unit for the monoidal structure).
-- The morphisms are functors which preserve the unit in a lax/weak sense (i.e. a non-necessairly isomorphic morphism).
-- The 2-cells are natural transformations which (at the unit) preserves the morphism of the underlying functors.
+- The morphisms are functors which preserve the unit in a lax/weak sense (i.e. a non-necessarily isomorphic morphism).
+- The 2-cells are natural transformations which (at the unit) preserve the morphisms for source and target functor.
 *)
 
 Require Import UniMath.Foundations.All.
@@ -33,21 +33,19 @@ Section UnitLayer.
 
   Definition catcatsunit_disp_ob_mor : disp_cat_ob_mor bicat_of_univ_cats.
   Proof.
-    use tpair.
-    - exact (λ C, ob (C : univalent_category)).
-    - exact (λ C D IC ID F, (D : univalent_category)⟦ID, (pr1 F) IC⟧).
+    exists (λ C, ob (C : univalent_category)).
+    exact (λ C D IC ID F, (D : univalent_category)⟦ID, (pr1 F) IC⟧).
   Defined.
 
   Definition catcatsunit_disp_cat_data : disp_cat_data bicat_of_univ_cats.
   Proof.
+    exists catcatsunit_disp_ob_mor.
     use tpair.
-    - exact catcatsunit_disp_ob_mor.
-    - use tpair.
-      + intros C I.
-        exact (identity I).
-      + intros C D E F G IC ID IE puF puG.
-        cbn.
-        exact (puG · (functor_on_morphisms (pr1 G) puF)).
+    - intros C I.
+      exact (identity I).
+    - intros C D E F G IC ID IE puF puG.
+      cbn.
+      exact (puG · (functor_on_morphisms (pr1 G) puF)).
   Defined.
 
   Definition bicatcatsunit_disp_2cell_struct : disp_2cell_struct catcatsunit_disp_cat_data.
@@ -75,13 +73,13 @@ Section UnitLayer.
 
   Definition bicatcatsunit_disp_prebicat_ops : disp_prebicat_ops bicatcatsunit_disp_prebicat_1_id_comp_cells.
   Proof.
-    cbn in *; repeat split.
+    repeat split; cbn; unfold bicatcatsunit_disp_2cell_struct.
     - intros C D F IC ID puF.
       apply id_right.
     - intros C D F IC ID puF.
       etrans. { apply id_right. }
       etrans. {
-        apply cancel_precomposition.
+        apply maponpaths.
         apply functor_id.
       }
       apply id_right.
@@ -89,7 +87,7 @@ Section UnitLayer.
       etrans. { apply id_right. }
       apply id_left.
     - intros C D F IC ID puF.
-      apply cancel_precomposition.
+      apply maponpaths.
       apply pathsinv0.
       apply functor_id.
     - intros C D F IC ID puF.
@@ -97,23 +95,17 @@ Section UnitLayer.
       apply pathsinv0.
       apply id_left.
     - intros C D E W F G H IC ID IE IW puF puG puH.
-      cbn.
-      unfold bicatcatsunit_disp_2cell_struct.
-      cbn.
       etrans. { apply id_right. }
       etrans. {
-        apply cancel_precomposition.
+        apply maponpaths.
         apply functor_comp.
       }
       etrans. { apply assoc. }
       apply idpath.
     - intros C D E W F G H IC ID IE IW puF puG puH.
-      cbn.
-      unfold bicatcatsunit_disp_2cell_struct.
-      cbn.
       etrans.  { apply id_right. }
       etrans. { apply assoc'. }
-      apply cancel_precomposition.
+      apply maponpaths.
       apply pathsinv0.
       apply functor_comp.
     - intros C D F G H α β IC ID puF puG puH pucα pucβ.
@@ -124,30 +116,22 @@ Section UnitLayer.
       }
       apply pucβ.
     - intros C D E F G H α IC ID IE puF puG puH pucα.
-      cbn.
-      unfold bicatcatsunit_disp_2cell_struct.
-      cbn.
-      cbn.
       etrans. { apply assoc'. }
       etrans. {
-        apply cancel_precomposition.
+        apply maponpaths.
         apply (pr2 α).
       }
       etrans. { apply assoc. }
       apply cancel_postcomposition.
       apply pucα.
     - intros C D E F G H α IC ID IE puF puG puH pucα.
-      cbn.
-      unfold bicatcatsunit_disp_2cell_struct.
-      cbn.
-      cbn.
       etrans. { apply assoc'. }
       etrans. {
-        apply cancel_precomposition.
+        apply maponpaths.
+        cbn.
         apply (pathsinv0 (functor_comp _ _ _)).
       }
-      apply cancel_precomposition.
-      apply maponpaths.
+      do 2 apply maponpaths.
       apply pucα.
   Qed.
 
@@ -192,7 +176,7 @@ Section UnitLayer.
   Qed.
 
   Lemma dispadjequiv_to_iso (C : bicat_of_univ_cats) (IC ID : bicatcatsunit_disp_bicat C) :
-       (disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID) -> (Isos.z_iso IC ID).
+       disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID -> z_iso IC ID.
   Proof.
     intro equalunits.
     induction equalunits as [f adj].
@@ -203,30 +187,29 @@ Section UnitLayer.
     unfold nat_trans_id in dunit.
     cbn in dunit.
 
-    use tpair.
-    - exact finv.
-    - repeat (use tpair).
-      + exact f.
-      + unfold nat_trans_id in dunit.
-        unfold functor_identity in dunit.
-        cbn in *.
-        etrans. { apply (pathsinv0 dunit). }
-        apply id_left.
-      + unfold nat_trans_id in dcounit.
-        unfold functor_identity in dcounit.
-        apply pathsinv0.
-        etrans. { apply (pathsinv0 dcounit). }
-        apply id_right.
+    exists finv.
+    exists f.
+    split.
+    - unfold nat_trans_id in dunit.
+      unfold functor_identity in dunit.
+      cbn in *.
+      etrans. { apply (pathsinv0 dunit). }
+      apply id_left.
+    - unfold nat_trans_id in dcounit.
+      unfold functor_identity in dcounit.
+      apply pathsinv0.
+      etrans. { apply (pathsinv0 dcounit). }
+      apply id_right.
   Defined.
 
   Lemma iso_to_dispadjequiv (C : bicat_of_univ_cats) (IC ID : bicatcatsunit_disp_bicat C) :
-    (z_iso IC ID) -> (disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID).
+    z_iso IC ID -> disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID.
   Proof.
     intro i.
     induction i as [finv [f [li ri]]].
     split with f.
     unfold disp_left_adjoint_equivalence.
-    repeat (use tpair).
+    repeat (use tpair); try apply univalent_category_has_homsets.
     - exact finv.
     - etrans. { apply id_left. }
       exact (! li).
@@ -237,8 +220,6 @@ Section UnitLayer.
         apply ri.
       }
       apply id_right.
-    - apply univalent_category_has_homsets.
-    - apply univalent_category_has_homsets.
     - unfold disp_2cells.
       cbn in *.
       unfold bicatcatsunit_disp_2cell_struct.
@@ -247,19 +228,15 @@ Section UnitLayer.
         apply li.
       }
       apply id_left.
-    - apply univalent_category_has_homsets.
-    - apply univalent_category_has_homsets.
     - unfold disp_2cells.
       cbn in *.
       unfold bicatcatsunit_disp_2cell_struct.
       etrans. { apply id_left. }
       exact (! ri).
-    - apply univalent_category_has_homsets.
-    - apply univalent_category_has_homsets.
   Defined.
 
     Lemma iso_dispadjequiv_equivalence (C : bicat_of_univ_cats) (IC ID : bicatcatsunit_disp_bicat C) :
-    (z_iso IC ID) ≃ (disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID).
+    z_iso IC ID ≃ disp_adjoint_equivalence (idtoiso_2_0 C C (idpath C)) IC ID.
   Proof.
     use make_weq.
     - apply iso_to_dispadjequiv.
@@ -291,9 +268,9 @@ Section UnitLayer.
       set (i3 := (_ ,, (pr2 C) IC ID)).
       exact (i1 ∘ i3)%weq.
     - intro p.
-      induction p ; cbn.
+      induction p; cbn.
       use subtypePath.
-      + intro ; simpl.
+      + intro; simpl.
         apply (@isaprop_disp_left_adjoint_equivalence bicat_of_univ_cats  bicatcatsunit_disp_bicat).
         * exact univalent_cat_is_univalent_2_1.
         * exact bicatcatsunit_disp_prebicat_is_locally_univalent.


### PR DESCRIPTION
also a bit on formulations in the header (I would not say that F and G are the underlying functors of the natural transformation, but maybe something different was meant)

I find a bit unelegant a `use tpair`, directly followed by an `exact`.

I used Ltac a little bit more.

`cancel_precomposition` is nearly never used in recent developments.