### PR TITLE
only cosmetic operations

### DIFF
--- a/UniMath/CategoryTheory/rezk_completion.v
+++ b/UniMath/CategoryTheory/rezk_completion.v
@@ -43,9 +43,7 @@ Require Import UniMath.CategoryTheory.precomp_ess_surj.
 
 Section rezk.
 
-  Variable A : category.
-  Let hsA : has_homsets A := homset_property A.
-
+  Context (A : category).
 
 Definition category_Rezk_completion : category.
 Proof.
@@ -94,25 +92,23 @@ Definition is_initial_functor_from (C : precategory) (X : functor_from C) : UU
 
 Section rezk_universal_property.
 
-Variables A : category.
-Let hsA : has_homsets A := homset_property A.
+  Context (A : category).
 
 Section fix_a_category.
 
-Variable C : category.
-Hypothesis Ccat : is_univalent C.
+  Context (C : category) (Ccat : is_univalent C).
 
 Lemma pre_comp_rezk_eta_is_fully_faithful :
   fully_faithful
-    (@pre_composition_functor A (Rezk_completion A) C (Rezk_eta A)).
+    (pre_composition_functor _ _  C (Rezk_eta A)).
 Proof.
   apply pre_composition_with_ess_surj_and_fully_faithful_is_fully_faithful.
-  apply Rezk_eta_essentially_surjective.
-  apply Rezk_eta_fully_faithful.
+  - apply Rezk_eta_essentially_surjective.
+  - apply Rezk_eta_fully_faithful.
 Defined.
 
 Lemma pre_comp_rezk_eta_is_ess_surj :
-  essentially_surjective (@pre_composition_functor A (Rezk_completion A) C (Rezk_eta A)).
+  essentially_surjective (pre_composition_functor _ _ C (Rezk_eta A)).
 Proof.
   apply pre_composition_essentially_surjective.
   - apply Ccat.
@@ -121,7 +117,7 @@ Proof.
 Defined.
 
 Definition Rezk_adj_equiv : adj_equivalence_of_cats
-  (@pre_comp_functor A (Rezk_completion A) C (Rezk_eta A)).
+  (pre_composition_functor _ _ C (Rezk_eta A)).
 Proof.
   apply (@rad_equivalence_of_cats
            (functor_category (Rezk_completion A) C)
@@ -134,9 +130,7 @@ Defined.
 
 
 Theorem Rezk_eta_Universal_Property :
-  isweq (@pre_comp_functor A (Rezk_completion A)
-                           C
-                           (Rezk_eta A)).
+  isweq (pre_composition_functor _ _ C (Rezk_eta A)).
 Proof.
   apply adj_equiv_of_cats_is_weq_of_objects.
   - apply is_univalent_functor_category;
@@ -181,17 +175,11 @@ End rezk_universal_property.
 
 Section opp_rezk_universal_property.
 
-Variables A : category.
-Let hsA : has_homsets A := homset_property A.
-
-Let hsAop : has_homsets A^op := has_homsets_opp hsA.
-Let hsRAop : has_homsets (Rezk_completion A)^op :=
-           has_homsets_opp (Rezk_completion A).
+  Context (A : category).
 
 Section fix_a_category.
 
-Variable C : category.
-Hypothesis Ccat : is_univalent C.
+  Context (C : category) (Ccat : is_univalent C).
 
 Lemma pre_comp_rezk_eta_opp_is_fully_faithful :
     fully_faithful
@@ -207,7 +195,7 @@ Defined.
 
 Lemma pre_comp_rezk_eta_opp_is_ess_surj :
    essentially_surjective
-      (@pre_comp_functor (op_category A) (op_category (Rezk_completion A)) C
+      (pre_composition_functor A^op (Rezk_completion A)^op C
                          (functor_opp (Rezk_eta A))).
 Proof.
   apply pre_composition_essentially_surjective.
@@ -220,11 +208,11 @@ Defined.
 
 Definition Rezk_op_adj_equiv :
  adj_equivalence_of_cats
-     (@pre_comp_functor (op_category A) (op_category (Rezk_completion A)) C
+     (pre_composition_functor A^op (Rezk_completion A)^op C
         (functor_opp (Rezk_eta A))).
 Proof.
   apply (@rad_equivalence_of_cats
-           [(op_category (Rezk_completion A)), C]
+           [(Rezk_completion A)^op, C]
            [A^op, C]
            (is_univalent_functor_category _ _ Ccat )
            _
@@ -233,7 +221,7 @@ Proof.
 Defined.
 
 Theorem Rezk_eta_opp_Universal_Property :
-  isweq (@pre_comp_functor (op_category A) (op_category (Rezk_completion A)) C
+  isweq (pre_composition_functor A^op (Rezk_completion A)^op C
           (functor_opp (Rezk_eta A))).
 Proof.
   apply adj_equiv_of_cats_is_weq_of_objects.


### PR DESCRIPTION
throws out variables for homsets, more coherence in notation and implicit arguments, use of command Context