### PR TITLE
replaces two proofs by reference to an upstream lemma

### DIFF
--- a/UniMath/CategoryTheory/DisplayedCats/Constructions.v
+++ b/UniMath/CategoryTheory/DisplayedCats/Constructions.v
@@ -19,6 +19,7 @@ Require Import UniMath.CategoryTheory.Core.Categories.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Functors.
+Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.FunctorCategory.
 
 Require Import UniMath.CategoryTheory.DisplayedCats.Core.
@@ -90,6 +91,15 @@ Proof.
 Defined.
 
 Definition full_subcat (C : category) (P : C → UU) : category := total_category (disp_full_sub C P).
+
+Definition is_univalent_full_subcat (C : category) (univC : is_univalent C) (P : C → UU) :
+  (∏ x : C, isaprop (P x)) → is_univalent (full_subcat C P).
+Proof.
+  intro H.
+  apply is_univalent_total_category.
+  - exact univC.
+  - exact (disp_full_sub_univalent _ _ H).
+Defined.
 
 End full_subcat.
 

--- a/UniMath/CategoryTheory/Subcategory/Full.v
+++ b/UniMath/CategoryTheory/Subcategory/Full.v
@@ -73,6 +73,37 @@ Definition full_sub_category (C : category)
   : category
   := make_category _ (has_homsets_full_sub_precategory C C').
 
+Definition full_sub_category_pr_data
+           {C : category}
+           (C': hsubtype (ob C))
+  : functor_data (full_sub_category C C') C.
+Proof.
+  use make_functor_data.
+  - exact (λ h, pr1 h).
+  - exact (λ h₁ h₂ α, pr1 α).
+Defined.
+
+Definition full_sub_category_pr_is_functor
+           {C : category}
+           (C': hsubtype (ob C))
+  : is_functor (full_sub_category_pr_data C').
+Proof.
+  split.
+  - intro x ; cbn.
+    apply idpath.
+  - intros x y z f g ; cbn.
+    apply idpath.
+Qed.
+
+Definition full_sub_category_pr
+           {C : category}
+           (C': hsubtype (ob C))
+  : full_sub_category C C' ⟶ C.
+Proof.
+  use make_functor.
+  - exact (full_sub_category_pr_data C').
+  - exact (full_sub_category_pr_is_functor C').
+Defined.
 
 (** ** The inclusion of a full subcategory is fully faithful *)
 

--- a/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
@@ -112,14 +112,7 @@ Section CoEilenbergMooreCategory.
     use make_is_z_isomorphism.
     - use make_mor_co_eilenberg_moore.
       + exact (inv_from_z_iso H).
-      + abstract
-          (refine (!_);
-           use z_iso_inv_on_right;
-           rewrite assoc;
-           rewrite functor_on_inv_from_z_iso;
-           use z_iso_inv_on_left;
-           refine (!_);
-           exact (pr21 f)).
+      + apply (is_z_iso_disp_dialgebra _ _ Hf (pr21 f)).
      - split.
       + abstract
           (use eq_mor_co_eilenberg_moore ; cbn ;

--- a/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
@@ -190,36 +190,14 @@ Definition eq_of_co_eilenberg_moore_mor
 (**
  4.1 The cone
  *)
-Definition co_eilenberg_moore_pr_data
-           {C : category}
-           (m : Comonad C)
-  : functor_data (co_eilenberg_moore_cat m) C.
-Proof.
-  use make_functor_data.
-  - exact (λ h, ob_of_co_eilenberg_moore_ob h).
-  - exact (λ h₁ h₂ α, mor_of_co_eilenberg_moore_mor α).
-Defined.
-
-Definition co_eilenberg_moore_pr_is_functor
-           {C : category}
-           (m : Comonad C)
-  : is_functor (co_eilenberg_moore_pr_data m).
-Proof.
-  split.
-  - intro x ; cbn.
-    apply idpath.
-  - intros x y z f g ; cbn.
-    apply idpath.
-Qed.
-
 Definition co_eilenberg_moore_pr
            {C : category}
            (m : Comonad C)
   : co_eilenberg_moore_cat m ⟶ C.
 Proof.
-  use make_functor.
-  - exact (co_eilenberg_moore_pr_data m).
-  - exact (co_eilenberg_moore_pr_is_functor m).
+  refine (functor_composite _ _).
+  - exact (full_sub_category_pr (C:=dialgebra (functor_identity _) m) (co_eilenberg_moore_cat_pred m)).
+  - apply dialgebra_pr1.
 Defined.
 
 Definition co_eilenberg_moore_nat_trans

--- a/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/CoEilenbergMoore.v
@@ -25,8 +25,8 @@ Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.categories.Dialgebras.
-Require Import UniMath.CategoryTheory.Subcategory.Core.
-Require Import UniMath.CategoryTheory.Subcategory.Full.
+Require Import UniMath.CategoryTheory.DisplayedCats.Total.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.Monads.Comonads.
 
 Local Open Scope cat.
@@ -51,7 +51,7 @@ Section CoEilenbergMooreCategory.
 
   Definition co_eilenberg_moore_cat
     : category
-    := full_sub_category
+    := full_subcat
          (dialgebra (functor_identity _) m)
          co_eilenberg_moore_cat_pred.
 
@@ -65,6 +65,7 @@ Section CoEilenbergMooreCategory.
     apply is_univalent_full_subcat.
     apply is_univalent_dialgebra.
     exact HC.
+    apply co_eilenberg_moore_cat_pred.
   Defined.
 
   (**
@@ -196,7 +197,7 @@ Definition co_eilenberg_moore_pr
   : co_eilenberg_moore_cat m ⟶ C.
 Proof.
   refine (functor_composite _ _).
-  - exact (full_sub_category_pr (C:=dialgebra (functor_identity _) m) (co_eilenberg_moore_cat_pred m)).
+  - apply pr1_category.
   - apply dialgebra_pr1.
 Defined.
 

--- a/UniMath/CategoryTheory/categories/EilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/EilenbergMoore.v
@@ -26,8 +26,8 @@ Require Import UniMath.CategoryTheory.Core.NaturalTransformations.
 Require Import UniMath.CategoryTheory.Core.Isos.
 Require Import UniMath.CategoryTheory.Core.Univalence.
 Require Import UniMath.CategoryTheory.categories.Dialgebras.
-Require Import UniMath.CategoryTheory.Subcategory.Core.
-Require Import UniMath.CategoryTheory.Subcategory.Full.
+Require Import UniMath.CategoryTheory.DisplayedCats.Total.
+Require Import UniMath.CategoryTheory.DisplayedCats.Constructions.
 Require Import UniMath.CategoryTheory.Monads.Monads.
 
 Local Open Scope cat.
@@ -52,7 +52,7 @@ Section EilenbergMooreCategory.
 
   Definition eilenberg_moore_cat
     : category
-    := full_sub_category
+    := full_subcat
          (dialgebra m (functor_identity _))
          eilenberg_moore_cat_pred.
 
@@ -66,6 +66,7 @@ Section EilenbergMooreCategory.
     apply is_univalent_full_subcat.
     apply is_univalent_dialgebra.
     exact HC.
+    apply eilenberg_moore_cat_pred.
   Defined.
 
   (**
@@ -197,7 +198,7 @@ Definition eilenberg_moore_pr
   : eilenberg_moore_cat m ⟶ C.
 Proof.
   refine (functor_composite _ _).
-  - exact (full_sub_category_pr (C:=dialgebra m (functor_identity _)) (eilenberg_moore_cat_pred m)).
+  - apply pr1_category.
   - apply dialgebra_pr1.
 Defined.
 

--- a/UniMath/CategoryTheory/categories/EilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/EilenbergMoore.v
@@ -113,14 +113,7 @@ Section EilenbergMooreCategory.
     use make_is_z_isomorphism.
     - use make_mor_eilenberg_moore.
       + exact (inv_from_z_iso H).
-      + abstract
-          (refine (!_) ;
-           use z_iso_inv_on_left ;
-           rewrite !assoc' ;
-           rewrite functor_on_inv_from_z_iso ;
-           refine (!_) ;
-           use z_iso_inv_on_right ;
-           exact (pr21 f)).
+      + apply (is_z_iso_disp_dialgebra _ _ Hf (pr21 f)).
     - split.
       + abstract
           (use eq_mor_eilenberg_moore ; cbn ;

--- a/UniMath/CategoryTheory/categories/EilenbergMoore.v
+++ b/UniMath/CategoryTheory/categories/EilenbergMoore.v
@@ -191,36 +191,14 @@ Definition eq_of_eilenberg_moore_mor
 (**
  4.1 The cone
  *)
-Definition eilenberg_moore_pr_data
-           {C : category}
-           (m : Monad C)
-  : functor_data (eilenberg_moore_cat m) C.
-Proof.
-  use make_functor_data.
-  - exact (λ h, ob_of_eilenberg_moore_ob h).
-  - exact (λ h₁ h₂ α, mor_of_eilenberg_moore_mor α).
-Defined.
-
-Definition eilenberg_moore_pr_is_functor
-           {C : category}
-           (m : Monad C)
-  : is_functor (eilenberg_moore_pr_data m).
-Proof.
-  split.
-  - intro x ; cbn.
-    apply idpath.
-  - intros x y z f g ; cbn.
-    apply idpath.
-Qed.
-
 Definition eilenberg_moore_pr
            {C : category}
            (m : Monad C)
   : eilenberg_moore_cat m ⟶ C.
 Proof.
-  use make_functor.
-  - exact (eilenberg_moore_pr_data m).
-  - exact (eilenberg_moore_pr_is_functor m).
+  refine (functor_composite _ _).
+  - exact (full_sub_category_pr (C:=dialgebra m (functor_identity _)) (eilenberg_moore_cat_pred m)).
+  - apply dialgebra_pr1.
 Defined.
 
 Definition eilenberg_moore_nat_trans

--- a/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
@@ -61,17 +61,14 @@ Section CofreeAdjunction.
   Defined.
 
   Local Definition eilenberg_moore_forget
-    : full_subcat (dialgebra (functor_identity 𝕃) (linear_category_bang 𝕃))
-        (mon_cat_co_eilenberg_moore_extra_condition (linear_category_bang 𝕃)) ⟶ 𝕃.
-    (* : co_eilenberg_moore_cat (linear_category_bang L) ⟶ L. *)
+    : co_eilenberg_moore_cat (linear_category_bang 𝕃) ⟶ 𝕃.
   Proof.
     exact (functor_composite (pr1_category _) (pr1_category _)).
   Defined.
 
   Local Definition eilenberg_moore_adj_unit
     : functor_identity
-        (full_subcat (dialgebra (functor_identity 𝕃) (linear_category_bang 𝕃))
-           (mon_cat_co_eilenberg_moore_extra_condition (linear_category_bang 𝕃))) ⟹
+        (co_eilenberg_moore_cat (linear_category_bang 𝕃)) ⟹
         eilenberg_moore_forget ∙ eilenberg_moore_cofree.
   Proof.
     use make_nat_trans.
@@ -108,8 +105,7 @@ Section CofreeAdjunction.
 
   Definition eilenberg_moore_cmd_adj
     : adjunction
-    (full_subcat (dialgebra (functor_identity 𝕃) (linear_category_bang 𝕃))
-       (mon_cat_co_eilenberg_moore_extra_condition (linear_category_bang 𝕃))) 𝕃.
+    (co_eilenberg_moore_cat (linear_category_bang 𝕃)) 𝕃.
   Proof.
     use make_adjunction.
     - simple refine (_ ,, _ ,, _ ,, _).

--- a/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategoryEilenbergMooreAdjunction.v
@@ -60,16 +60,10 @@ Section CofreeAdjunction.
           exact (Comonad_law3 (T := linear_category_bang 𝕃) x)).
   Defined.
 
-  Local Definition eilenberg_moore_forget
-    : co_eilenberg_moore_cat (linear_category_bang 𝕃) ⟶ 𝕃.
-  Proof.
-    exact (functor_composite (pr1_category _) (pr1_category _)).
-  Defined.
-
   Local Definition eilenberg_moore_adj_unit
     : functor_identity
         (co_eilenberg_moore_cat (linear_category_bang 𝕃)) ⟹
-        eilenberg_moore_forget ∙ eilenberg_moore_cofree.
+        co_eilenberg_moore_pr (linear_category_bang 𝕃) ∙ eilenberg_moore_cofree.
   Proof.
     use make_nat_trans.
     - intro x.
@@ -88,7 +82,7 @@ Section CofreeAdjunction.
 
   Lemma eilenberg_moore_cmd_form_adj
     :  form_adjunction'
-         (eilenberg_moore_forget,,
+         (co_eilenberg_moore_pr (linear_category_bang 𝕃),,
             eilenberg_moore_cofree,,
             eilenberg_moore_adj_unit,,
             ε (linear_category_bang 𝕃)).
@@ -109,7 +103,7 @@ Section CofreeAdjunction.
   Proof.
     use make_adjunction.
     - simple refine (_ ,, _ ,, _ ,, _).
-      + exact eilenberg_moore_forget.
+      + exact (co_eilenberg_moore_pr (linear_category_bang 𝕃)).
       + exact eilenberg_moore_cofree.
       + exact eilenberg_moore_adj_unit.
       + exact (ε (linear_category_bang 𝕃)).


### PR DESCRIPTION
This came up when studying your PR even though it is in files not touched by your PR. It certainly does not merit a separate PR to UniMath.

Also a clean-up w.r.t. to what notion of full subcategory is used.