### PR TITLE
creates structure from last two axioms of linear category

### DIFF
--- a/UniMath/Semantics/LinearLogic/LinearCategory.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategory.v
@@ -178,13 +178,13 @@ Definition linear_category_laws
                   · mon_functor_unit (linear_category_bang_functor 𝕃)
                   #⊗ mon_functor_unit (linear_category_bang_functor 𝕃))
      ×
-     (* bang preserves tensor *)
+     (* counit preserves tensor *)
      (∏ x y : 𝕃, mon_functor_tensor (linear_category_bang_functor 𝕃) x y
                            · linear_category_counit 𝕃 (x ⊗ y)
                          = linear_category_counit 𝕃 x #⊗ linear_category_counit 𝕃 y
                              · mon_lunitor (monoidal_unit 𝕃))
      ×
-     (* bang preserves unit *)
+     (* counit preserves unit *)
      (mon_functor_unit (linear_category_bang_functor 𝕃)
                 · linear_category_counit 𝕃 I_{𝕃}
               = identity I_{𝕃}).

--- a/UniMath/Semantics/LinearLogic/LinearCategory.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategory.v
@@ -333,7 +333,7 @@ Section AccessorsLaws.
     exact (pr122 (pr222 (pr222 (pr222 𝕃)))).
   Qed.
 
-  Proposition linear_category_bang_preserves_tensor
+  Proposition linear_category_counit_preserves_tensor
     (x y : 𝕃)
     : mon_functor_tensor (linear_category_bang_functor 𝕃) x y
         · linear_category_counit 𝕃 (x ⊗ y)
@@ -343,7 +343,7 @@ Section AccessorsLaws.
     exact (pr1 (pr222 (pr222 (pr222 (pr222 𝕃)))) x y).
   Qed.
 
-  Proposition linear_category_bang_preserves_unit
+  Proposition linear_category_counit_preserves_unit
     : mon_functor_unit (linear_category_bang_functor 𝕃)
         · linear_category_counit 𝕃 I_{𝕃}
       = identity I_{𝕃}.
@@ -413,14 +413,14 @@ Proof.
        apply linear_category_counit_nat).
 Defined.
 
-Definition linear_category_bang_is_mon_nat_trans
+Definition linear_category_counit_is_mon_nat_trans
   (𝕃 : linear_category):
   is_mon_nat_trans (linear_category_bang_functor 𝕃)
     (constant_functor_fmonoidal_lax _ (unit_monoid 𝕃)) (linear_category_counit_nat_trans 𝕃).
 Proof.
   split.
-  - intros x y. apply linear_category_bang_preserves_tensor.
-  - apply linear_category_bang_preserves_unit.
+  - intros x y. apply linear_category_counit_preserves_tensor.
+  - apply linear_category_counit_preserves_unit.
 Defined.
 
 Definition linear_category_comult_coalgebra_morphism

--- a/UniMath/Semantics/LinearLogic/LinearCategory.v
+++ b/UniMath/Semantics/LinearLogic/LinearCategory.v
@@ -23,6 +23,8 @@ Require Import UniMath.CategoryTheory.Monoidal.Structure.Symmetric.
 Require Import UniMath.CategoryTheory.Monoidal.Structure.SymmetricDiagonal.
 Require Import UniMath.CategoryTheory.Monoidal.Structure.Closed.
 Require Import UniMath.CategoryTheory.Monoidal.Comonoids.Category.
+Require Import UniMath.CategoryTheory.Monoidal.Examples.ConstantFunctor.
+Require Import UniMath.CategoryTheory.Monoidal.CategoriesOfMonoids.
 Require Import UniMath.CategoryTheory.categories.Dialgebras.
 
 Import MonoidalNotations.
@@ -176,13 +178,13 @@ Definition linear_category_laws
                   · mon_functor_unit (linear_category_bang_functor 𝕃)
                   #⊗ mon_functor_unit (linear_category_bang_functor 𝕃))
      ×
-     (* counit preserves tensor *)
+     (* bang preserves tensor *)
      (∏ x y : 𝕃, mon_functor_tensor (linear_category_bang_functor 𝕃) x y
                            · linear_category_counit 𝕃 (x ⊗ y)
                          = linear_category_counit 𝕃 x #⊗ linear_category_counit 𝕃 y
                              · mon_lunitor (monoidal_unit 𝕃))
      ×
-     (* counit preserves unit *)
+     (* bang preserves unit *)
      (mon_functor_unit (linear_category_bang_functor 𝕃)
                 · linear_category_counit 𝕃 I_{𝕃}
               = identity I_{𝕃}).
@@ -331,7 +333,7 @@ Section AccessorsLaws.
     exact (pr122 (pr222 (pr222 (pr222 𝕃)))).
   Qed.
 
-  Proposition linear_category_counit_preserves_tensor
+  Proposition linear_category_bang_preserves_tensor
     (x y : 𝕃)
     : mon_functor_tensor (linear_category_bang_functor 𝕃) x y
         · linear_category_counit 𝕃 (x ⊗ y)
@@ -341,7 +343,7 @@ Section AccessorsLaws.
     exact (pr1 (pr222 (pr222 (pr222 (pr222 𝕃)))) x y).
   Qed.
 
-  Proposition linear_category_counit_preserves_unit
+  Proposition linear_category_bang_preserves_unit
     : mon_functor_unit (linear_category_bang_functor 𝕃)
         · linear_category_counit 𝕃 I_{𝕃}
       = identity I_{𝕃}.
@@ -409,6 +411,16 @@ Proof.
       (intros x y f ; cbn ;
        rewrite id_right ;
        apply linear_category_counit_nat).
+Defined.
+
+Definition linear_category_bang_is_mon_nat_trans
+  (𝕃 : linear_category):
+  is_mon_nat_trans (linear_category_bang_functor 𝕃)
+    (constant_functor_fmonoidal_lax _ (unit_monoid 𝕃)) (linear_category_counit_nat_trans 𝕃).
+Proof.
+  split.
+  - intros x y. apply linear_category_bang_preserves_tensor.
+  - apply linear_category_bang_preserves_unit.
 Defined.
 
 Definition linear_category_comult_coalgebra_morphism

--- a/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
+++ b/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
@@ -535,7 +535,7 @@ Section EilenbergMooreCartesian.
           use eq_mor_co_eilenberg_moore;
           refine (assoc' _ _ _ @ _);
           refine (id_left _ @ _);
-          apply linear_category_counit_preserves_unit).
+          apply linear_category_bang_preserves_unit).
     - intros x y.
       use eq_mor_co_eilenberg_moore.
       apply aux.

--- a/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
+++ b/UniMath/Semantics/LinearLogic/LinearToLinearNonLinear.v
@@ -535,7 +535,7 @@ Section EilenbergMooreCartesian.
           use eq_mor_co_eilenberg_moore;
           refine (assoc' _ _ _ @ _);
           refine (id_left _ @ _);
-          apply linear_category_bang_preserves_unit).
+          apply linear_category_counit_preserves_unit).
     - intros x y.
       use eq_mor_co_eilenberg_moore.
       apply aux.


### PR DESCRIPTION
this is just that bang is a monoidal nat. trans., therefore the axioms are renamed to reflect that purpose

the part on preservation of tensor is not used elsewhere

This is the easy part of the proposal in my last comment to your PR.